### PR TITLE
Add GitHub Actions Workflow for mdBook Deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy mdBook to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main  # Run the workflow on pushes to the main branch
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    # Step 1: Checkout the repository
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Step 2: Install Rust stable toolchain and mdBook dependencies
+    - name: Install Rust and mdBook
+      run: |
+        rustup toolchain install stable
+        rustup default stable
+        cargo install mdbook --version 0.4.21
+        cargo install mdbook-svgbob --locked
+        curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.21/mdbook-v0.4.21-x86_64-unknown-linux-gnu.tar.gz | tar xvz
+
+    # Step 3: Build the book
+    - name: Build the mdBook
+      run: ./mdbook build
+
+    # Step 4: Deploy the book to GitHub Pages
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./book


### PR DESCRIPTION
This PR introduces a GitHub Actions workflow to automate the building and deployment of the **rust-mdbook** documentation to GitHub Pages. By adding the `.github/workflows/deploy.yml` file, the workflow is configured to trigger on pushes to the `main` branch, build the mdBook, and deploy the generated site to the `gh-pages` branch.

#### Changes

- **Added `.github/workflows/deploy.yml`**:
  - **Checkout Repository**: Uses `actions/checkout@v3` to clone the repository.
  - **Install Rust and mdBook**: Installs the stable Rust toolchain, mdBook, and necessary dependencies.
  - **Build mdBook**: Executes the build process for the book.
  - **Deploy to GitHub Pages**: Utilizes `peaceiris/actions-gh-pages@v3` to publish the built site to the `gh-pages` branch.

```yaml
name: Deploy mdBook to GitHub Pages

on:
  push:
    branches:
      - main  # Run the workflow on pushes to the main branch

jobs:
  build-and-deploy:
    runs-on: ubuntu-latest

    steps:
    # Step 1: Checkout the repository
    - name: Checkout repository
      uses: actions/checkout@v3

    # Step 2: Install Rust stable toolchain and mdBook dependencies
    - name: Install Rust and mdBook
      run: |
        rustup toolchain install stable
        rustup default stable
        cargo install mdbook --version 0.4.21
        cargo install mdbook-svgbob --locked
        curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.21/mdbook-v0.4.21-x86_64-unknown-linux-gnu.tar.gz | tar xvz

    # Step 3: Build the book
    - name: Build the mdBook
      run: ./mdbook build

    # Step 4: Deploy the book to GitHub Pages
    - name: Deploy to GitHub Pages
      uses: peaceiris/actions-gh-pages@v3
      with:
        github_token: ${{ secrets.GITHUB_TOKEN }}
        publish_dir: ./book
```

#### Setup Instructions

1. **Enable GitHub Pages**:
   - Navigate to your repository on GitHub.
   - Go to **Settings** > **Pages**.
   - In the **Source** section:
     - Select `Deploy from a branch`.
     - Choose the `gh-pages` branch (it will be created by the workflow upon the first deployment).
   - Save the settings.

2. **Verify Deployment**:
   - Push a change to the `main` branch or trigger the workflow manually via the **Actions** tab.
   - Monitor the workflow progress in the **Actions** tab.
   - Once successful, your site will be available at:
     ```
     https://bidouilles.github.io/rust-mdbook/
     ```

#### Benefits

- **Automated Deployment**: Streamlines the process of publishing updates to your documentation without manual intervention.
- **Consistency**: Ensures that the latest changes on the `main` branch are always reflected on GitHub Pages.
- **Efficiency**: Saves time and reduces the potential for human error in the deployment process.

#### Additional Notes

- **Configuration**: Ensure your `book.toml` is properly configured, especially the `[output.html]` section for customizing the output if needed.
- **Custom Domain**: To use a custom domain, add a `CNAME` file in your `book/` directory.

---

Feel free to review the workflow file and let me know if any adjustments are needed!